### PR TITLE
Fix error multiple return null

### DIFF
--- a/resources/views/selection-table-handler.blade.php
+++ b/resources/views/selection-table-handler.blade.php
@@ -27,7 +27,7 @@
             }
 
             {{-- Prevent bulk select checkboxes from breaking stuff --}}
-            if (records.length > selectionLimit) {
+            if (selectionLimit !== null && records.length > selectionLimit) {
                 suppressWatcherForNextCycle = true;
                 selectedRecords = [...cachedSelectedRecords];
 
@@ -65,12 +65,11 @@
         suppressWatcherForNextCycle: true,
 
         updateCheckboxSelectability(records) {
-            const checkboxes = $wire.$el.querySelectorAll('.fi-ta-record-checkbox');
-
-            if (selectionLimit === 1) {
+            if (selectionLimit === 1 || selectionLimit === null) {
                 return;
             }
 
+            const checkboxes = $wire.$el.querySelectorAll('.fi-ta-record-checkbox');
             const limitReached = records.length >= selectionLimit;
 
             checkboxes.forEach(checkbox => checkbox.disabled = !checkbox.checked && limitReached);

--- a/src/Components/Form/Concerns/HasSelectionModalCreateOptionAction.php
+++ b/src/Components/Form/Concerns/HasSelectionModalCreateOptionAction.php
@@ -127,18 +127,19 @@ trait HasSelectionModalCreateOptionAction
                 if ($component->evaluate($component->requiresSelectionConfirmation)) {
                     $statePath = Js::from($component->getStatePath());
                     $createdOptionKey = Js::from($createdOptionKey);
+                    $selectionLimit = Js::from($selectionLimit);
 
                     $component->getLivewire()->js(<<<JS
-                        if ({$selectionLimit} === 1) {
+                        if ($selectionLimit === 1) {
                             Alpine.store('selectionModalCache').set($statePath, [$createdOptionKey]);
-        
+
                             return;
                         }
-        
-                        if (Alpine.store('selectionModalCache').get($statePath)?.length >= $selectionLimit) {
+
+                        if ($selectionLimit !== null && Alpine.store('selectionModalCache').get($statePath)?.length >= $selectionLimit) {
                             return;
                         }
-        
+
                         Alpine.store('selectionModalCache').push($statePath, $createdOptionKey);
                     JS);
                 } elseif ($selectionLimit === 1 || $selectionLimit >= count($state)) {

--- a/src/Components/Form/Concerns/HasSelectionTable.php
+++ b/src/Components/Form/Concerns/HasSelectionTable.php
@@ -36,7 +36,7 @@ trait HasSelectionTable
 
     protected ?Closure $modifySelectionConfirmationActionUsing = null;
 
-    abstract public function getSelectionLimit(): int;
+    abstract public function getSelectionLimit(): ?int;
 
     abstract public function isMultiple(): bool;
 

--- a/src/Components/Form/TableSelect.php
+++ b/src/Components/Form/TableSelect.php
@@ -120,7 +120,7 @@ class TableSelect extends Field
         ]);
     }
 
-    protected function getSelectionLimit(): int
+    protected function getSelectionLimit(): ?int
     {
         return $this->isMultiple() ? $this->getMaxItems() : 1;
     }


### PR DESCRIPTION
Adjusting the return type to ?int in the case when the TableSelect type is a multiple and maxItems is not defined and it returns null and in the method signature it is only int.
